### PR TITLE
Remove double `https://doi.org` from Hawkins+Tivey:2024 DOI

### DIFF
--- a/docs/paper/refs.bib
+++ b/docs/paper/refs.bib
@@ -158,7 +158,7 @@
  address = {Jeju, Korea},
  editor = {},
  ISBN = {},
- doi = {https://doi.org/10.1145/3676581.3676582}
+ doi = {10.1145/3676581.3676582}
 }
 
 @inproceedings{Hawkins:2023,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/524b1c73-0984-476c-a218-4e6f0540d304)